### PR TITLE
Issue #6: Use -h to specify whois lookup server on all OSes

### DIFF
--- a/src/connectors/connectorARINrir.js
+++ b/src/connectors/connectorARINrir.js
@@ -171,7 +171,7 @@ export default class ConnectorARIN extends Connector {
         } else {
 
             return new Promise((resolve, reject) => {
-                const flag = "-h";
+                const flag = "h";
                 const output = execSync(`whois -${flag} whois.arin.net "r > ${prefix}"`, { encoding: 'utf-8' })
 
                 this._writeFile(file, output.split("\n")).then(resolve);

--- a/src/connectors/connectorARINrir.js
+++ b/src/connectors/connectorARINrir.js
@@ -171,7 +171,7 @@ export default class ConnectorARIN extends Connector {
         } else {
 
             return new Promise((resolve, reject) => {
-                const flag = process.platform === "darwin" ? "s" : "h";
+                const flag = "-h";
                 const output = execSync(`whois -${flag} whois.arin.net "r > ${prefix}"`, { encoding: 'utf-8' })
 
                 this._writeFile(file, output.split("\n")).then(resolve);


### PR DESCRIPTION
MacOS Sequoia 15.5 no longer likes the -s flag to specify the Whois server's name